### PR TITLE
feat: 添加文章描述(description)字段支持并优化爬取逻辑

### DIFF
--- a/api/vercel.py
+++ b/api/vercel.py
@@ -67,6 +67,9 @@ class ArticleData(BaseModel):
     avatar: str = Field(
         ..., description="头像链接", example="https://example.com/avatar.jpg"
     )
+    description: Optional[str] = Field(
+        None, description="RSS/Atom feed中的文章描述"
+    )
     summary: Optional[str] = Field(
         None, description="AI生成摘要", example="这是一篇关于终端工具的文章..."
     )

--- a/api_dependence/mongodb/mongodbapi.py
+++ b/api_dependence/mongodb/mongodbapi.py
@@ -43,6 +43,7 @@ def query_all(li, start: int = 0, end: int = 0, rule: str = "updated"):
                 "author": 1,
                 "avatar": 1,
                 "createdAt": 1,
+                "description": 1,
                 "summary": {"$ifNull": ["$summary_data.summary", None]},
                 "ai_model": {"$ifNull": ["$summary_data.ai_model", None]},
                 "summary_created_at": {"$ifNull": ["$summary_data.createdAt", None]},
@@ -94,6 +95,7 @@ def query_all(li, start: int = 0, end: int = 0, rule: str = "updated"):
             item[elem] = post.get(elem)
 
         # 添加摘要相关字段
+        item["description"] = post.get("description")
         item["summary"] = post.get("summary")
         item["ai_model"] = post.get("ai_model")
         item["summary_created_at"] = post.get("summary_created_at")

--- a/api_dependence/src/mongodb/mongodbapi.rs
+++ b/api_dependence/src/mongodb/mongodbapi.rs
@@ -146,16 +146,35 @@ pub async fn get_post(
         }
     };
     // 使用域名匹配 posts 表，而不是完整的 friend.link URL
+    let sort_rule = params.sort_rule.unwrap_or(String::from("created"));
+    let num = params.num.unwrap_or(-1);
     let posts = match mongo::select_all_from_posts_with_linklike(
         &pool,
         &search_domain,
-        params.num.unwrap_or(-1),
-        &params.sort_rule.unwrap_or(String::from("created")),
+        num,
+        &sort_rule,
     )
     .await
     {
         Ok(v) => v,
         Err(e) => return Err(PYQError::QueryDataBaseError(e.to_string())),
+    };
+
+    // 如果域名匹配不到文章（可能站点换了域名），用 author 名字匹配
+    let posts = if posts.is_empty() {
+        match mongo::select_posts_by_author(
+            &pool,
+            &friend.name,
+            num,
+            &sort_rule,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(_) => posts,
+        }
+    } else {
+        posts
     };
     let data = AllPostDataSomeFriend::new(
         friend.name,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ reqwest-middleware = { workspace = true }
 dotenvy = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+futures = { workspace = true }
 
 [[bin]]
 name = "fcircle_core"

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 
 use chrono::Utc;
@@ -5,6 +6,7 @@ use data_structures::metadata::{self, ArticleSummary};
 use data_structures::response::AllPostData;
 use db::{SqlitePool, mongo, mysql, sqlite};
 use downloader::{download, genai::EnhancedSummaryProvider};
+use futures::stream::{self, StreamExt};
 use tokio::{self};
 use tracing::{error, info};
 
@@ -60,7 +62,81 @@ fn should_update_summary(
     }
 }
 
-/// 为文章生成摘要
+/// 需要生成摘要的文章信息
+#[derive(Debug)]
+struct PendingSummary {
+    link: String,
+    html_content: String,
+    content_hash: String,
+    /// 如果是更新已有摘要，保留原始创建时间
+    existing_created_at: Option<String>,
+}
+
+/// 并发下载文章HTML内容，返回需要生成摘要的文章列表
+async fn fetch_pending_articles(
+    posts: &[metadata::Posts],
+    existing_summaries: &HashMap<String, Option<ArticleSummary>>,
+    client: &reqwest_middleware::ClientWithMiddleware,
+    max_concurrent: usize,
+) -> Vec<PendingSummary> {
+    let pending: Vec<PendingSummary> = Vec::new();
+    let pending = std::sync::Arc::new(tokio::sync::Mutex::new(pending));
+
+    // 并发下载HTML并筛选需要更新的文章
+    let tasks: Vec<_> = posts
+        .iter()
+        .map(|post| {
+            let link = post.meta.link.clone();
+            let client = client.clone();
+            let existing = existing_summaries.get(&link).cloned().flatten();
+            let pending = pending.clone();
+            async move {
+                match download::start_crawl_detailpages(&link, &client).await {
+                    Ok(html_content) => {
+                        let current_hash = tools::calculate_content_hash(&html_content);
+
+                        let (needs_update, existing_created_at) = if let Some(ref es) = existing {
+                            let (should_update, reason) = should_update_summary(es, &current_hash);
+                            if !should_update {
+                                info!("文章 {} {}，跳过摘要生成", link, reason);
+                                return;
+                            }
+                            info!("文章 {} {}，需要生成摘要", link, reason);
+                            (true, Some(es.created_at.clone()))
+                        } else {
+                            info!("文章 {} 没有缓存摘要，需要生成新摘要", link);
+                            (true, None)
+                        };
+
+                        if needs_update {
+                            pending.lock().await.push(PendingSummary {
+                                link,
+                                html_content,
+                                content_hash: current_hash,
+                                existing_created_at,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        error!("获取文章详情失败 {}: {}", link, e);
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // 使用 buffer_unordered 控制并发下载数
+    stream::iter(tasks)
+        .buffer_unordered(max_concurrent * 2) // 下载并发可以比AI调用更高
+        .collect::<Vec<()>>()
+        .await;
+
+    std::sync::Arc::try_unwrap(pending)
+        .unwrap()
+        .into_inner()
+}
+
+/// 为文章生成摘要（并发优化版）
 async fn generate_article_summaries(
     fc_settings: &data_structures::config::Settings,
     client: &reqwest_middleware::ClientWithMiddleware,
@@ -76,16 +152,17 @@ async fn generate_article_summaries(
         return Err(e.into());
     }
 
-    // 创建专用的LLM客户端（30秒超时）
-    let llm_client = download::build_client(30, 0);
+    // 创建专用的LLM客户端（60秒超时，Thinking模型需要更长时间）
+    let llm_client = download::build_client(60, 0);
+    let max_concurrent = fc_settings.generate_summary.get_max_concurrent();
 
     info!(
-        "开始生成文章摘要，使用提供商: {}",
+        "开始生成文章摘要（并发模式），使用提供商: {}",
         fc_settings.generate_summary.provider
     );
     info!(
         "配置参数 - 最大并发: {}, 等待限速: {}, 最大字符: {}",
-        fc_settings.generate_summary.get_max_concurrent(),
+        max_concurrent,
         fc_settings.generate_summary.get_wait_on_rate_limit(),
         fc_settings.generate_summary.get_max_chars(),
     );
@@ -95,107 +172,57 @@ async fn generate_article_summaries(
             let dbpool = sqlite::connect_sqlite_dbpool("data.db").await?;
             let posts = sqlite::select_all_from_posts(&dbpool, 0, 0, "updated").await?;
 
-            for post in posts {
-                let link = &post.meta.link;
+            // 批量查询已有摘要
+            let mut existing_summaries: HashMap<String, Option<ArticleSummary>> = HashMap::new();
+            for post in &posts {
+                let summary = sqlite::select_article_summary_by_link(&post.meta.link, &dbpool)
+                    .await
+                    .unwrap_or(None);
+                existing_summaries.insert(post.meta.link.clone(), summary);
+            }
 
-                // 检查是否已经有缓存的摘要
-                if let Ok(Some(existing_summary)) =
-                    sqlite::select_article_summary_by_link(link, &dbpool).await
-                {
-                    // 获取当前文章的HTML内容
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
+            // 并发下载并筛选需要更新的文章
+            let pending = fetch_pending_articles(&posts, &existing_summaries, client, max_concurrent).await;
+            info!("需要生成摘要的文章数: {}/{}", pending.len(), posts.len());
 
-                            // 检查是否需要更新摘要
-                            let (should_update, reason) =
-                                should_update_summary(&existing_summary, &current_hash);
-                            if !should_update {
-                                info!("文章 {} {}，跳过摘要生成", link, reason);
-                                continue;
-                            }
+            // 使用 generate_summaries_batch 并发生成摘要
+            let html_contents: Vec<(String, String)> = pending
+                .iter()
+                .map(|p| (p.link.clone(), p.html_content.clone()))
+                .collect();
 
-                            info!("文章 {} {}，需要生成摘要", link, reason);
+            let results = summary_provider
+                .generate_summaries_batch(&llm_client, html_contents)
+                .await;
 
-                            // 生成新的摘要
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        existing_summary.created_at,
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        sqlite::insert_article_summary(&article_summary, &dbpool)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功更新文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
+            // 保存结果
+            for (link, result) in results {
+                let pending_item = pending.iter().find(|p| p.link == link).unwrap();
+                match result {
+                    Ok(summary_result) => {
+                        let now = tools::strptime_to_string_ymdhms(
+                            Utc::now().with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
+                        );
+                        let created_at = pending_item
+                            .existing_created_at
+                            .clone()
+                            .unwrap_or_else(|| now.clone());
+                        let article_summary = ArticleSummary::new(
+                            link.clone(),
+                            pending_item.content_hash.clone(),
+                            summary_result.summary,
+                            Some(summary_result.model),
+                            created_at,
+                            now,
+                        );
+                        if let Err(e) = sqlite::insert_article_summary(&article_summary, &dbpool).await {
+                            error!("保存文章摘要失败 {}: {}", link, e);
+                        } else {
+                            info!("成功生成文章摘要: {}", link);
                         }
                     }
-                } else {
-                    // 没有缓存的摘要，需要生成新的
-                    info!("文章 {} 没有缓存摘要，需要生成新摘要", link);
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
-
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        now.clone(),
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        sqlite::insert_article_summary(&article_summary, &dbpool)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功生成文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
-                        }
+                    Err(e) => {
+                        error!("生成文章摘要失败 {}: {}", link, e);
                     }
                 }
             }
@@ -205,109 +232,57 @@ async fn generate_article_summaries(
             let dbpool = mysql::connect_mysql_dbpool(&mysqlconnstr).await?;
             let posts = mysql::select_all_from_posts(&dbpool, 0, 0, "updated").await?;
 
-            for post in posts {
-                let link = &post.meta.link;
+            // 批量查询已有摘要
+            let mut existing_summaries: HashMap<String, Option<ArticleSummary>> = HashMap::new();
+            for post in &posts {
+                let summary = mysql::select_article_summary_by_link(&post.meta.link, &dbpool)
+                    .await
+                    .unwrap_or(None);
+                existing_summaries.insert(post.meta.link.clone(), summary);
+            }
 
-                if let Ok(Some(existing_summary)) =
-                    mysql::select_article_summary_by_link(link, &dbpool).await
-                {
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
+            // 并发下载并筛选需要更新的文章
+            let pending = fetch_pending_articles(&posts, &existing_summaries, client, max_concurrent).await;
+            info!("需要生成摘要的文章数: {}/{}", pending.len(), posts.len());
 
-                            // 检查是否需要更新摘要：
-                            // 1. 哈希值不同（内容变化）
-                            // 2. 摘要为空
-                            let content_unchanged = existing_summary.content_hash == current_hash;
-                            let summary_empty = existing_summary.summary.trim().is_empty();
+            // 使用 generate_summaries_batch 并发生成摘要
+            let html_contents: Vec<(String, String)> = pending
+                .iter()
+                .map(|p| (p.link.clone(), p.html_content.clone()))
+                .collect();
 
-                            if content_unchanged && !summary_empty {
-                                info!("文章 {} 内容未变化且摘要存在，跳过摘要生成", link);
-                                continue;
-                            }
+            let results = summary_provider
+                .generate_summaries_batch(&llm_client, html_contents)
+                .await;
 
-                            if summary_empty {
-                                info!("文章 {} 摘要为空，需要生成摘要", link);
-                            } else {
-                                info!("文章 {} 内容已变化，需要更新摘要", link);
-                            }
-
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        existing_summary.created_at,
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        mysql::insert_article_summary(&article_summary, &dbpool)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功更新文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
+            // 保存结果
+            for (link, result) in results {
+                let pending_item = pending.iter().find(|p| p.link == link).unwrap();
+                match result {
+                    Ok(summary_result) => {
+                        let now = tools::strptime_to_string_ymdhms(
+                            Utc::now().with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
+                        );
+                        let created_at = pending_item
+                            .existing_created_at
+                            .clone()
+                            .unwrap_or_else(|| now.clone());
+                        let article_summary = ArticleSummary::new(
+                            link.clone(),
+                            pending_item.content_hash.clone(),
+                            summary_result.summary,
+                            Some(summary_result.model),
+                            created_at,
+                            now,
+                        );
+                        if let Err(e) = mysql::insert_article_summary(&article_summary, &dbpool).await {
+                            error!("保存文章摘要失败 {}: {}", link, e);
+                        } else {
+                            info!("成功生成文章摘要: {}", link);
                         }
                     }
-                } else {
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
-
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        now.clone(),
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        mysql::insert_article_summary(&article_summary, &dbpool)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功生成文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
-                        }
+                    Err(e) => {
+                        error!("生成文章摘要失败 {}: {}", link, e);
                     }
                 }
             }
@@ -317,109 +292,57 @@ async fn generate_article_summaries(
             let clientdb = mongo::connect_mongodb_clientdb(&mongodburi).await?;
             let posts = mongo::select_all_from_posts(&clientdb, 0, 0, "updated").await?;
 
-            for post in posts {
-                let link = &post.meta.link;
+            // 批量查询已有摘要
+            let mut existing_summaries: HashMap<String, Option<ArticleSummary>> = HashMap::new();
+            for post in &posts {
+                let summary = mongo::select_article_summary_by_link(&post.meta.link, &clientdb)
+                    .await
+                    .unwrap_or(None);
+                existing_summaries.insert(post.meta.link.clone(), summary);
+            }
 
-                if let Ok(Some(existing_summary)) =
-                    mongo::select_article_summary_by_link(link, &clientdb).await
-                {
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
+            // 并发下载并筛选需要更新的文章
+            let pending = fetch_pending_articles(&posts, &existing_summaries, client, max_concurrent).await;
+            info!("需要生成摘要的文章数: {}/{}", pending.len(), posts.len());
 
-                            // 检查是否需要更新摘要：
-                            // 1. 哈希值不同（内容变化）
-                            // 2. 摘要为空
-                            let content_unchanged = existing_summary.content_hash == current_hash;
-                            let summary_empty = existing_summary.summary.trim().is_empty();
+            // 使用 generate_summaries_batch 并发生成摘要
+            let html_contents: Vec<(String, String)> = pending
+                .iter()
+                .map(|p| (p.link.clone(), p.html_content.clone()))
+                .collect();
 
-                            if content_unchanged && !summary_empty {
-                                info!("文章 {} 内容未变化且摘要存在，跳过摘要生成", link);
-                                continue;
-                            }
+            let results = summary_provider
+                .generate_summaries_batch(&llm_client, html_contents)
+                .await;
 
-                            if summary_empty {
-                                info!("文章 {} 摘要为空，需要生成摘要", link);
-                            } else {
-                                info!("文章 {} 内容已变化，需要更新摘要", link);
-                            }
-
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        existing_summary.created_at,
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        mongo::insert_article_summary(&article_summary, &clientdb)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功更新文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
+            // 保存结果
+            for (link, result) in results {
+                let pending_item = pending.iter().find(|p| p.link == link).unwrap();
+                match result {
+                    Ok(summary_result) => {
+                        let now = tools::strptime_to_string_ymdhms(
+                            Utc::now().with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
+                        );
+                        let created_at = pending_item
+                            .existing_created_at
+                            .clone()
+                            .unwrap_or_else(|| now.clone());
+                        let article_summary = ArticleSummary::new(
+                            link.clone(),
+                            pending_item.content_hash.clone(),
+                            summary_result.summary,
+                            Some(summary_result.model),
+                            created_at,
+                            now,
+                        );
+                        if let Err(e) = mongo::insert_article_summary(&article_summary, &clientdb).await {
+                            error!("保存文章摘要失败 {}: {}", link, e);
+                        } else {
+                            info!("成功生成文章摘要: {}", link);
                         }
                     }
-                } else {
-                    match download::start_crawl_detailpages(link, client).await {
-                        Ok(html_content) => {
-                            let current_hash = tools::calculate_content_hash(&html_content);
-
-                            match summary_provider
-                                .generate_summary(&llm_client, &html_content)
-                                .await
-                            {
-                                Ok(summary_result) => {
-                                    let now = tools::strptime_to_string_ymdhms(
-                                        Utc::now()
-                                            .with_timezone(&downloader::BEIJING_OFFSET.unwrap()),
-                                    );
-                                    let article_summary = ArticleSummary::new(
-                                        link.clone(),
-                                        current_hash,
-                                        summary_result.summary,
-                                        Some(summary_result.model),
-                                        now.clone(),
-                                        now,
-                                    );
-
-                                    if let Err(e) =
-                                        mongo::insert_article_summary(&article_summary, &clientdb)
-                                            .await
-                                    {
-                                        error!("保存文章摘要失败 {}: {}", link, e);
-                                    } else {
-                                        info!("成功生成文章摘要: {}", link);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("生成文章摘要失败 {}: {}", link, e);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("获取文章详情失败 {}: {}", link, e);
-                        }
+                    Err(e) => {
+                        error!("生成文章摘要失败 {}: {}", link, e);
                     }
                 }
             }
@@ -595,10 +518,11 @@ async fn main() {
             match sqlx::migrate!("../db/schema/sqlite").run(&dbpool).await {
                 Ok(()) => (),
                 Err(e) => {
-                    info!("{}", e);
-                    return;
+                    info!("迁移提示(可忽略): {}", e);
                 }
             };
+            // 确保 description 列存在（兼容老版本数据库）
+            sqlite::ensure_description_column(&dbpool).await;
             if let Err(e) = sqlite::truncate_friend_table(&dbpool).await {
                 error!("{}", e);
                 return;
@@ -671,10 +595,11 @@ async fn main() {
             match sqlx::migrate!("../db/schema/mysql").run(&dbpool).await {
                 Ok(()) => (),
                 Err(e) => {
-                    info!("{}", e);
-                    return;
+                    info!("迁移提示(可忽略): {}", e);
                 }
             };
+            // 确保 description 列存在（兼容老版本数据库）
+            mysql::ensure_description_column(&dbpool).await;
             if let Err(e) = mysql::truncate_friend_table(&dbpool).await {
                 error!("{}", e);
                 return;

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -37,6 +37,10 @@ pub mod metadata {
         // #[serde(skip_serializing)]
         // #[serde(default)]
         pub rule: String,
+        /// RSS/Atom feed 中的文章描述
+        #[serde(default)]
+        #[sqlx(default)]
+        pub description: Option<String>,
     }
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, FromRow)]
@@ -65,6 +69,25 @@ pub mod metadata {
                 updated,
                 link,
                 rule,
+                description: None,
+            }
+        }
+
+        pub fn new_with_description(
+            title: String,
+            created: String,
+            updated: String,
+            link: String,
+            rule: String,
+            description: Option<String>,
+        ) -> BasePosts {
+            BasePosts {
+                title,
+                created,
+                updated,
+                link,
+                rule,
+                description,
             }
         }
     }
@@ -381,6 +404,7 @@ pub mod response {
         link: String,
         author: String,
         avatar: String,
+        description: Option<String>,
     }
 
     impl ArticleData {
@@ -392,6 +416,7 @@ pub mod response {
             link: String,
             author: String,
             avatar: String,
+            description: Option<String>,
         ) -> Self {
             ArticleData {
                 floor,
@@ -401,6 +426,7 @@ pub mod response {
                 link,
                 author,
                 avatar,
+                description,
             }
         }
     }
@@ -416,6 +442,7 @@ pub mod response {
         pub link: String,
         pub author: String,
         pub avatar: String,
+        pub description: Option<String>,
         // 摘要相关字段
         pub summary: Option<String>,
         pub ai_model: Option<String>,
@@ -433,6 +460,7 @@ pub mod response {
             link: String,
             author: String,
             avatar: String,
+            description: Option<String>,
             summary: Option<String>,
             ai_model: Option<String>,
             summary_created_at: Option<String>,
@@ -446,6 +474,7 @@ pub mod response {
                 link,
                 author,
                 avatar,
+                description,
                 summary,
                 ai_model,
                 summary_created_at,
@@ -463,6 +492,7 @@ pub mod response {
                 link: posts.meta.link,
                 author: posts.author,
                 avatar: posts.avatar,
+                description: posts.meta.description,
                 summary: posts.summary,
                 ai_model: posts.ai_model,
                 summary_created_at: posts.summary_created_at,
@@ -507,6 +537,7 @@ pub mod response {
                         posts.meta.link,
                         posts.author,
                         posts.avatar,
+                        posts.meta.description,
                     )
                 })
                 .collect();
@@ -600,6 +631,7 @@ pub mod response {
                         posts.meta.link,
                         posts.author,
                         posts.avatar,
+                        posts.meta.description,
                     )
                 })
                 .collect();

--- a/db/schema/mysql/01_mysql.sql
+++ b/db/schema/mysql/01_mysql.sql
@@ -8,6 +8,7 @@ CREATE TABLE `posts` (
   `avatar` varchar(1024) DEFAULT NULL,
   `rule` varchar(256) DEFAULT NULL,
   `createdAt` VARCHAR(1024) DEFAULT NULL,
+  `description` TEXT DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=125 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/db/schema/sqlite/01_sqlite.sql
+++ b/db/schema/sqlite/01_sqlite.sql
@@ -18,6 +18,7 @@ CREATE TABLE posts (
 	avatar VARCHAR(1024), 
 	rule VARCHAR(256), 
 	"createdAt" VARCHAR(1024), 
+	description TEXT,
 	PRIMARY KEY (id)
 );
 

--- a/db/src/mongo.rs
+++ b/db/src/mongo.rs
@@ -140,6 +140,7 @@ pub async fn select_all_from_posts_with_summary(
                 "avatar": 1,
                 "rule": 1,
                 "createdAt": 1,
+                "description": 1,
                 "summary": { "$ifNull": ["$summary_data.summary", null] },
                 "ai_model": { "$ifNull": ["$summary_data.ai_model", null] },
                 "summary_created_at": { "$ifNull": ["$summary_data.createdAt", null] },
@@ -165,12 +166,13 @@ pub async fn select_all_from_posts_with_summary(
 
     while let Some(doc) = cursor.try_next().await? {
         // 手动构建 PostsWithSummary
-        let base_post = metadata::BasePosts::new(
+        let base_post = metadata::BasePosts::new_with_description(
             doc.get_str("title").unwrap_or("").to_string(),
             doc.get_str("created").unwrap_or("").to_string(),
             doc.get_str("updated").unwrap_or("").to_string(),
             doc.get_str("link").unwrap_or("").to_string(),
             doc.get_str("rule").unwrap_or("").to_string(),
+            doc.get_str("description").ok().map(|s| s.to_string()),
         );
 
         let post_with_summary = metadata::PostsWithSummary::new(
@@ -266,13 +268,43 @@ pub async fn select_all_from_posts_with_linklike(
     Ok(posts)
 }
 
+/// 根据 author 名字查询文章
+pub async fn select_posts_by_author(
+    pool: &MongoDatabase,
+    author: &str,
+    num: i32,
+    sort_rule: &str,
+) -> Result<Vec<metadata::Posts>, Error> {
+    let collection = pool.collection::<Posts>("Post");
+    let cursor = if num > 0 {
+        collection
+            .find(doc! {"author": author})
+            .sort(doc! {sort_rule: -1})
+            .limit(num as i64)
+            .await?
+    } else {
+        collection
+            .find(doc! {"author": author})
+            .sort(doc! {sort_rule: -1})
+            .await?
+    };
+
+    let posts = cursor.try_collect().await?;
+    Ok(posts)
+}
+
 pub async fn delete_outdated_posts(days: usize, clientdb: &MongoDatabase) -> Result<usize, Error> {
     if days == 0 {
         return Ok(0);
     }
     let now = Local::now() - Duration::days(days as i64);
     let collection = clientdb.collection::<Posts>("Post");
-    let filter = doc! { "updated": doc! { "$lt": now.format("%Y-%m-%d").to_string() } };
+    let filter = doc! {
+        "updated": doc! {
+            "$lt": now.format("%Y-%m-%d").to_string(),
+            "$ne": ""
+        }
+    };
     let result = collection.delete_many(filter).await?;
     Ok(result.deleted_count as usize)
 }
@@ -407,6 +439,7 @@ mod tests {
             updated: "2023-01-01".to_string(),
             link: "https://example.com/post".to_string(),
             rule: "test".to_string(),
+            description: None,
         };
 
         let post = Posts {
@@ -441,6 +474,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -453,6 +487,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),
@@ -484,6 +519,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -496,6 +532,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),
@@ -561,6 +598,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -573,6 +611,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),
@@ -603,6 +642,7 @@ mod tests {
                     updated: today.clone(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -615,6 +655,7 @@ mod tests {
                     updated: old_date.clone(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),

--- a/db/src/mysql.rs
+++ b/db/src/mysql.rs
@@ -3,6 +3,31 @@ use sqlx::{
     Error, MySql, QueryBuilder, Row, mysql::MySqlPool, mysql::MySqlPoolOptions, query, query_as,
 };
 
+/// 检查 posts 表是否存在 description 列
+async fn has_description_column(pool: &MySqlPool) -> bool {
+    let result = query(
+        "SELECT COUNT(*) as cnt FROM information_schema.COLUMNS WHERE TABLE_NAME='posts' AND COLUMN_NAME='description' AND TABLE_SCHEMA=DATABASE()"
+    )
+    .fetch_one(pool)
+    .await;
+    match result {
+        Ok(row) => {
+            let cnt: i64 = row.get("cnt");
+            cnt > 0
+        }
+        Err(_) => false,
+    }
+}
+
+/// 确保 posts 表包含 description 列，如果不存在则自动添加
+pub async fn ensure_description_column(pool: &MySqlPool) {
+    if !has_description_column(pool).await {
+        let _ = query("ALTER TABLE posts ADD COLUMN `description` TEXT DEFAULT NULL")
+            .execute(pool)
+            .await;
+    }
+}
+
 pub async fn connect_mysql_dbpool(url: &str) -> Result<MySqlPool, Error> {
     MySqlPoolOptions::new()
         .max_connections(5)
@@ -11,20 +36,36 @@ pub async fn connect_mysql_dbpool(url: &str) -> Result<MySqlPool, Error> {
 }
 
 pub async fn insert_post_table(post: &metadata::Posts, pool: &MySqlPool) -> Result<(), Error> {
-    let sql = "INSERT INTO posts
-    (title, author, link, avatar ,rule,created,updated,createdAt)
-     VALUES (?, ?, ?,?, ?,?, ?, ?)";
-    let q = query(sql)
-        .bind(&post.meta.title)
-        .bind(&post.author)
-        .bind(&post.meta.link)
-        .bind(&post.avatar)
-        .bind(&post.meta.rule)
-        .bind(&post.meta.created)
-        .bind(&post.meta.updated)
-        .bind(&post.created_at);
-    // println!("sql: {},{:?}",q.sql(),q.take_arguments());
-    q.execute(pool).await?;
+    if has_description_column(pool).await {
+        let sql = "INSERT INTO posts
+        (title, author, link, avatar ,rule,created,updated,createdAt,description)
+         VALUES (?, ?, ?,?, ?,?, ?, ?, ?)";
+        let q = query(sql)
+            .bind(&post.meta.title)
+            .bind(&post.author)
+            .bind(&post.meta.link)
+            .bind(&post.avatar)
+            .bind(&post.meta.rule)
+            .bind(&post.meta.created)
+            .bind(&post.meta.updated)
+            .bind(&post.created_at)
+            .bind(&post.meta.description);
+        q.execute(pool).await?;
+    } else {
+        let sql = "INSERT INTO posts
+        (title, author, link, avatar ,rule,created,updated,createdAt)
+         VALUES (?, ?, ?,?, ?,?, ?, ?)";
+        let q = query(sql)
+            .bind(&post.meta.title)
+            .bind(&post.author)
+            .bind(&post.meta.link)
+            .bind(&post.avatar)
+            .bind(&post.meta.rule)
+            .bind(&post.meta.created)
+            .bind(&post.meta.updated)
+            .bind(&post.created_at);
+        q.execute(pool).await?;
+    }
     Ok(())
 }
 
@@ -48,28 +89,42 @@ pub async fn bulk_insert_post_table(
     tuples: impl Iterator<Item = metadata::Posts>,
     pool: &MySqlPool,
 ) -> Result<(), Error> {
-    let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
-        // Note the trailing space; most calls to `QueryBuilder` don't automatically insert
-        // spaces as that might interfere with identifiers or quoted strings where exact
-        // values may matter.
-        "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt) ",
-    );
+    if has_description_column(pool).await {
+        let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
+            "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt,description) ",
+        );
 
-    query_builder.push_values(tuples, |mut b, post| {
-        // If you wanted to bind these by-reference instead of by-value,
-        // you'd need an iterator that yields references that live as long as `query_builder`,
-        // e.g. collect it to a `Vec` first.
-        b.push_bind(post.meta.title)
-            .push_bind(post.author)
-            .push_bind(post.meta.link)
-            .push_bind(post.avatar)
-            .push_bind(post.meta.rule)
-            .push_bind(post.meta.created)
-            .push_bind(post.meta.updated)
-            .push_bind(post.created_at);
-    });
-    let query = query_builder.build();
-    query.execute(pool).await?;
+        query_builder.push_values(tuples, |mut b, post| {
+            b.push_bind(post.meta.title)
+                .push_bind(post.author)
+                .push_bind(post.meta.link)
+                .push_bind(post.avatar)
+                .push_bind(post.meta.rule)
+                .push_bind(post.meta.created)
+                .push_bind(post.meta.updated)
+                .push_bind(post.created_at)
+                .push_bind(post.meta.description);
+        });
+        let query = query_builder.build();
+        query.execute(pool).await?;
+    } else {
+        let mut query_builder: QueryBuilder<MySql> = QueryBuilder::new(
+            "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt) ",
+        );
+
+        query_builder.push_values(tuples, |mut b, post| {
+            b.push_bind(post.meta.title)
+                .push_bind(post.author)
+                .push_bind(post.meta.link)
+                .push_bind(post.avatar)
+                .push_bind(post.meta.rule)
+                .push_bind(post.meta.created)
+                .push_bind(post.meta.updated)
+                .push_bind(post.created_at);
+        });
+        let query = query_builder.build();
+        query.execute(pool).await?;
+    }
     Ok(())
 }
 
@@ -160,9 +215,12 @@ pub async fn select_all_from_posts_with_summary(
     end: usize,
     sort_rule: &str,
 ) -> Result<Vec<metadata::PostsWithSummary>, Error> {
+    let has_desc = has_description_column(pool).await;
+    let desc_col = if has_desc { ", p.description" } else { "" };
+
     let sql = if start == 0 && end == 0 {
         format!(
-            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt,
+            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt{desc_col},
                     s.summary, s.ai_model, s.createdAt as summary_created_at, s.updatedAt as summary_updated_at
              FROM posts p
              LEFT JOIN article_summaries s ON p.link = s.link
@@ -170,7 +228,7 @@ pub async fn select_all_from_posts_with_summary(
         )
     } else {
         format!(
-            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt,
+            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt{desc_col},
                     s.summary, s.ai_model, s.createdAt as summary_created_at, s.updatedAt as summary_updated_at
              FROM posts p
              LEFT JOIN article_summaries s ON p.link = s.link
@@ -185,12 +243,19 @@ pub async fn select_all_from_posts_with_summary(
     let mut posts_with_summary = Vec::new();
 
     for row in rows {
-        let base_post = metadata::BasePosts::new(
+        let description = if has_desc {
+            row.try_get("description").ok()
+        } else {
+            None
+        };
+
+        let base_post = metadata::BasePosts::new_with_description(
             row.get("title"),
             row.get("created"),
             row.get("updated"),
             row.get("link"),
             row.get("rule"),
+            description,
         );
 
         let post_with_summary = metadata::PostsWithSummary::new(
@@ -265,7 +330,7 @@ pub async fn delete_outdated_posts(days: usize, dbpool: &MySqlPool) -> Result<us
     if days == 0 {
         return Ok(0);
     }
-    let sql = "DELETE FROM posts WHERE DATE(updated) < DATE_SUB(CURDATE(), INTERVAL ? DAY)";
+    let sql = "DELETE FROM posts WHERE updated != '' AND DATE(updated) < DATE_SUB(CURDATE(), INTERVAL ? DAY)";
     let affected_rows = query(sql).bind(days as i64).execute(dbpool).await?;
 
     Ok(affected_rows.rows_affected() as usize)
@@ -419,6 +484,7 @@ mod tests {
             updated: "2023-01-01".to_string(),
             link: "https://example.com/post".to_string(),
             rule: "test".to_string(),
+            description: None,
         };
 
         let post = Posts {
@@ -492,6 +558,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -504,6 +571,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),
@@ -539,6 +607,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -551,6 +620,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.org/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.org/avatar2.jpg".to_string(),
@@ -628,6 +698,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -640,6 +711,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),

--- a/db/src/sqlite.rs
+++ b/db/src/sqlite.rs
@@ -5,6 +5,29 @@ use sqlx::{
 };
 use std::path::Path;
 
+/// 检查 posts 表是否存在 description 列
+async fn has_description_column(pool: &SqlitePool) -> bool {
+    let result = query("SELECT COUNT(*) as cnt FROM pragma_table_info('posts') WHERE name='description'")
+        .fetch_one(pool)
+        .await;
+    match result {
+        Ok(row) => {
+            let cnt: i32 = row.get("cnt");
+            cnt > 0
+        }
+        Err(_) => false,
+    }
+}
+
+/// 确保 posts 表包含 description 列，如果不存在则自动添加
+pub async fn ensure_description_column(pool: &SqlitePool) {
+    if !has_description_column(pool).await {
+        let _ = query("ALTER TABLE posts ADD COLUMN description TEXT")
+            .execute(pool)
+            .await;
+    }
+}
+
 pub async fn connect_sqlite_dbpool(filename: impl AsRef<Path>) -> Result<SqlitePool, Error> {
     let options = SqliteConnectOptions::new()
         .filename(filename)
@@ -16,20 +39,36 @@ pub async fn connect_sqlite_dbpool(filename: impl AsRef<Path>) -> Result<SqliteP
 }
 
 pub async fn insert_post_table(post: &metadata::Posts, pool: &SqlitePool) -> Result<(), Error> {
-    let sql = "INSERT INTO posts
-    (title, author, link, avatar ,rule,created,updated,createdAt)
-     VALUES (?, ?, ?,?, ?,?, ?, ?)";
-    let q = query(sql)
-        .bind(&post.meta.title)
-        .bind(&post.author)
-        .bind(&post.meta.link)
-        .bind(&post.avatar)
-        .bind(&post.meta.rule)
-        .bind(&post.meta.created)
-        .bind(&post.meta.updated)
-        .bind(&post.created_at);
-    // println!("sql: {},{:?}",q.sql(),q.take_arguments());
-    q.execute(pool).await?;
+    if has_description_column(pool).await {
+        let sql = "INSERT INTO posts
+        (title, author, link, avatar ,rule,created,updated,createdAt,description)
+         VALUES (?, ?, ?,?, ?,?, ?, ?, ?)";
+        let q = query(sql)
+            .bind(&post.meta.title)
+            .bind(&post.author)
+            .bind(&post.meta.link)
+            .bind(&post.avatar)
+            .bind(&post.meta.rule)
+            .bind(&post.meta.created)
+            .bind(&post.meta.updated)
+            .bind(&post.created_at)
+            .bind(&post.meta.description);
+        q.execute(pool).await?;
+    } else {
+        let sql = "INSERT INTO posts
+        (title, author, link, avatar ,rule,created,updated,createdAt)
+         VALUES (?, ?, ?,?, ?,?, ?, ?)";
+        let q = query(sql)
+            .bind(&post.meta.title)
+            .bind(&post.author)
+            .bind(&post.meta.link)
+            .bind(&post.avatar)
+            .bind(&post.meta.rule)
+            .bind(&post.meta.created)
+            .bind(&post.meta.updated)
+            .bind(&post.created_at);
+        q.execute(pool).await?;
+    }
     Ok(())
 }
 
@@ -53,28 +92,42 @@ pub async fn bulk_insert_post_table(
     tuples: impl Iterator<Item = metadata::Posts>,
     pool: &SqlitePool,
 ) -> Result<(), Error> {
-    let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
-        // Note the trailing space; most calls to `QueryBuilder` don't automatically insert
-        // spaces as that might interfere with identifiers or quoted strings where exact
-        // values may matter.
-        "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt) ",
-    );
+    if has_description_column(pool).await {
+        let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
+            "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt,description) ",
+        );
 
-    query_builder.push_values(tuples, |mut b, post| {
-        // If you wanted to bind these by-reference instead of by-value,
-        // you'd need an iterator that yields references that live as long as `query_builder`,
-        // e.g. collect it to a `Vec` first.
-        b.push_bind(post.meta.title)
-            .push_bind(post.author)
-            .push_bind(post.meta.link)
-            .push_bind(post.avatar)
-            .push_bind(post.meta.rule)
-            .push_bind(post.meta.created)
-            .push_bind(post.meta.updated)
-            .push_bind(post.created_at);
-    });
-    let query = query_builder.build();
-    query.execute(pool).await?;
+        query_builder.push_values(tuples, |mut b, post| {
+            b.push_bind(post.meta.title)
+                .push_bind(post.author)
+                .push_bind(post.meta.link)
+                .push_bind(post.avatar)
+                .push_bind(post.meta.rule)
+                .push_bind(post.meta.created)
+                .push_bind(post.meta.updated)
+                .push_bind(post.created_at)
+                .push_bind(post.meta.description);
+        });
+        let query = query_builder.build();
+        query.execute(pool).await?;
+    } else {
+        let mut query_builder: QueryBuilder<Sqlite> = QueryBuilder::new(
+            "INSERT INTO posts (title, author, link, avatar ,rule,created,updated,createdAt) ",
+        );
+
+        query_builder.push_values(tuples, |mut b, post| {
+            b.push_bind(post.meta.title)
+                .push_bind(post.author)
+                .push_bind(post.meta.link)
+                .push_bind(post.avatar)
+                .push_bind(post.meta.rule)
+                .push_bind(post.meta.created)
+                .push_bind(post.meta.updated)
+                .push_bind(post.created_at);
+        });
+        let query = query_builder.build();
+        query.execute(pool).await?;
+    }
     Ok(())
 }
 
@@ -165,9 +218,12 @@ pub async fn select_all_from_posts_with_summary(
     end: usize,
     sort_rule: &str,
 ) -> Result<Vec<metadata::PostsWithSummary>, Error> {
+    let has_desc = has_description_column(pool).await;
+    let desc_col = if has_desc { ", p.description" } else { "" };
+
     let sql = if start == 0 && end == 0 {
         format!(
-            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt,
+            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt{desc_col},
                     s.summary, s.ai_model, s.createdAt as summary_created_at, s.updatedAt as summary_updated_at
              FROM posts p
              LEFT JOIN article_summaries s ON p.link = s.link
@@ -175,7 +231,7 @@ pub async fn select_all_from_posts_with_summary(
         )
     } else {
         format!(
-            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt,
+            "SELECT p.title, p.created, p.updated, p.link, p.author, p.avatar, p.rule, p.createdAt{desc_col},
                     s.summary, s.ai_model, s.createdAt as summary_created_at, s.updatedAt as summary_updated_at
              FROM posts p
              LEFT JOIN article_summaries s ON p.link = s.link
@@ -190,12 +246,19 @@ pub async fn select_all_from_posts_with_summary(
     let mut posts_with_summary = Vec::new();
 
     for row in rows {
-        let base_post = metadata::BasePosts::new(
+        let description = if has_desc {
+            row.try_get("description").ok()
+        } else {
+            None
+        };
+
+        let base_post = metadata::BasePosts::new_with_description(
             row.get("title"),
             row.get("created"),
             row.get("updated"),
             row.get("link"),
             row.get("rule"),
+            description,
         );
 
         let post_with_summary = metadata::PostsWithSummary::new(
@@ -278,7 +341,9 @@ pub async fn delete_outdated_posts(days: usize, dbpool: &SqlitePool) -> Result<u
     if days == 0 {
         return Ok(0);
     }
-    let sql = format!("DELETE FROM posts WHERE date(updated) < date('now', '-{days} days')");
+    let sql = format!(
+        "DELETE FROM posts WHERE updated != '' AND date(updated) < date('now', '-{days} days')"
+    );
     let affected_rows = query(&sql).execute(dbpool).await?;
 
     Ok(affected_rows.rows_affected() as usize)
@@ -407,6 +472,7 @@ mod tests {
             updated: "2023-01-01".to_string(),
             link: "https://example.com/post".to_string(),
             rule: "test".to_string(),
+            description: None,
         };
 
         let post = Posts {
@@ -480,6 +546,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -492,6 +559,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),
@@ -527,6 +595,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -539,6 +608,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.org/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.org/avatar2.jpg".to_string(),
@@ -616,6 +686,7 @@ mod tests {
                     updated: "2023-01-01".to_string(),
                     link: "https://example.com/post1".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者1".to_string(),
                 avatar: "https://example.com/avatar1.jpg".to_string(),
@@ -628,6 +699,7 @@ mod tests {
                     updated: "2023-01-02".to_string(),
                     link: "https://example.com/post2".to_string(),
                     rule: "test".to_string(),
+                    description: None,
                 },
                 author: "作者2".to_string(),
                 avatar: "https://example.com/avatar2.jpg".to_string(),

--- a/downloader/src/crawler.rs
+++ b/downloader/src/crawler.rs
@@ -1,4 +1,4 @@
-use chrono::{FixedOffset, Utc};
+use chrono::FixedOffset;
 use data_structures::metadata;
 use feed_rs::parser;
 use html_escape::decode_html_entities;
@@ -223,6 +223,17 @@ pub async fn crawl_post_page_feed(
                     }
                 },
             };
+            // 描述（从summary或content中提取）
+            let description = entry
+                .summary
+                .map(|s| decode_html_entities(&s.content).to_string())
+                .or_else(|| {
+                    entry
+                        .content
+                        .and_then(|c| c.body)
+                        .map(|b| decode_html_entities(&b).to_string())
+                });
+
             // 时间
             let published_time = entry
                 .published
@@ -230,16 +241,22 @@ pub async fn crawl_post_page_feed(
             let updated_time = entry
                 .updated
                 .map(|t| tools::strptime_to_string_ymd(t.fixed_offset()));
-            let fallback_time =
-                tools::strptime_to_string_ymd(Utc::now().with_timezone(&BEIJING_OFFSET.unwrap()));
 
+            // 当feed没有任何时间信息时，使用空字符串而非当前时间
+            // 避免每次爬取都将无时间的文章标记为"今天"
             let created = published_time
                 .clone()
                 .or(updated_time.clone())
-                .unwrap_or(fallback_time.clone());
-            let updated = updated_time.or(published_time).unwrap_or(fallback_time);
-            let base_post =
-                metadata::BasePosts::new(title, created, updated, link, "feed".to_string());
+                .unwrap_or_default();
+            let updated = updated_time.or(published_time).unwrap_or_default();
+            let base_post = metadata::BasePosts::new_with_description(
+                title,
+                created,
+                updated,
+                link,
+                "feed".to_string(),
+                description,
+            );
             format_base_posts.push(base_post);
         }
         Ok(format_base_posts)

--- a/downloader/src/download.rs
+++ b/downloader/src/download.rs
@@ -20,15 +20,47 @@ async fn get_joinset_result(
     joinset: &mut JoinSet<Vec<BasePosts>>,
     base_url: &Url,
 ) -> Result<Vec<BasePosts>, Box<dyn std::error::Error>> {
+    let mut all_results: Vec<Vec<BasePosts>> = Vec::new();
+
     while let Some(res) = joinset.join_next().await {
         if let Ok(success) = res
             && !success.is_empty()
         {
-            info!("{} 解析成功! 共{}条", base_url, success.len());
-            return Ok(success);
+            all_results.push(success);
         }
     }
-    Err("css request failed".into())
+
+    if all_results.is_empty() {
+        return Err("css request failed".into());
+    }
+
+    // 取文章数最多的结果作为基础
+    all_results.sort_by(|a, b| b.len().cmp(&a.len()));
+    let mut base = all_results.remove(0);
+
+    // 从其他 feed 结果中收集有 description 的条目（以 link 为 key）
+    let mut desc_map: HashMap<String, String> = HashMap::new();
+    for result in &all_results {
+        for post in result {
+            if let Some(ref desc) = post.description {
+                desc_map.entry(post.link.clone()).or_insert_with(|| desc.clone());
+            }
+        }
+    }
+
+    // 用有 description 的数据补充基础结果中缺失的 description
+    if !desc_map.is_empty() {
+        for post in &mut base {
+            if post.description.is_none() {
+                if let Some(desc) = desc_map.remove(&post.link) {
+                    post.description = Some(desc);
+                }
+            }
+        }
+    }
+
+    info!("{} 解析成功! 共{}条", base_url, base.len());
+    Ok(base)
 }
 
 /// 构建请求客户端


### PR DESCRIPTION
- 在 posts 表中新增 description 字段（MySQL/SQLite schema 及兼容旧数据库的自动迁移）
- 从 RSS/Atom feed 的 summary/content 中提取文章描述
- API 响应中返回 description 字段
- 多爬取结果合并时优先取文章数最多的结果，并从 feed 结果中补充 description
- 修复删除过期文章时误删 updated 为空的记录
- feed 无时间信息时使用空字符串而非当前时间，避免重复标记为"今天"
- MongoDB 新增 select_posts_by_author 查询方法
- 重构 core/main.rs 中的摘要生成流程