### PR TITLE
Fix Vercel schema validation for vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,29 +1,28 @@
 {
-    "version": 2,
-    "public": true,
-    "rewrites": [
-      {
-        "source": "/(.*)",
-        "destination": "/api/vercel.py"
-      }
-    ],
-    "headers": [
-      {
-        "source": "/(.*)",
-        "headers": [
-          {
-            "key": "Access-Control-Allow-Origin",
-            "value": "*"
-          },
-          {
-            "key": "Access-Control-Allow-Methods",
-            "value": "*"
-          },
-          {
-            "key": "Access-Control-Allow-Headers",
-            "value": "*"
-          }
-        ]
-      }
-    ]
-  }
+  "version": 2,
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/api/vercel.py"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Remove the unsupported `public` property from `vercel.json`.

## Why

Vercel now rejects this configuration during schema validation:

```text
The `vercel.json` schema validation failed with the following message: should NOT have additional property `public`
```

Deployment visibility and protection are controlled by Vercel project settings, so keeping `public` in `vercel.json` can block deployments.

## Changes

- Removed `public: true` from `vercel.json`
- Kept the existing rewrite to `/api/vercel.py`
- Kept the existing CORS headers unchanged

## Verification

- Confirmed the updated `vercel.json` is valid JSON
- Confirmed the PR diff only changes `vercel.json`

Closes #186